### PR TITLE
Update package.json for allowed "none" OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
             "Ubuntu-14",
             "Ubuntu-16",
             "Ubuntu-18",
-            "Ubuntu-19"
+            "Ubuntu-19",
+            "none"
           ]
         }
       }


### PR DESCRIPTION
I'm running on an unlisted Linux OS with the binaries in my path. VSCode is flagging setting this variable to none in my settings since it doesn't match the enumeration list.