### PR TITLE
use registerDocumentRangeFormattingEditProvider instead of registerDocumentRangeFormattingEditProvider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,16 +68,17 @@ const format = (
 
 // Extension is activated
 export function activate(context: vscode.ExtensionContext) {
-  vscode.languages.registerDocumentFormattingEditProvider('systemverilog', {
-    provideDocumentFormattingEdits(
+  vscode.languages.registerDocumentRangeFormattingEditProvider('systemverilog', {
+    provideDocumentRangeFormattingEdits(
       document: vscode.TextDocument,
+      range: vscode.Range,
     ): vscode.TextEdit[] {
       let filePath = document.uri.fsPath
       let currentText = document.getText()
-      let formattedFileContents = format(filePath, currentText)
+      let lines = [[range.start.line, range.end.line]]
 
       return [
-        vscode.TextEdit.replace(textRange(document), formattedFileContents),
+        vscode.TextEdit.replace(textRange(document), format(filePath, currentText, lines)),
       ]
     },
   })


### PR DESCRIPTION
Thank you for your extension.

This pull request adds Format Selection feature in addition to Format Document feature.

***

Some notes;

- Are there any reason not to use semicolon in extension.ts?  ES-linter, which you enabled, warns a lot.
- We don't have to define "systemverilog-formatter-vscode.formatDocument" and "systemverilog-formatter-vscode.formatSelection" commands.  The built-in "Format Document" and "Format Selection" commands do their jobs.

If you agree, I am happy to provide you fixes for above.

Again thank you for your sharing this extension.